### PR TITLE
include preferred resolver in reg-ex

### DIFF
--- a/R/crossrefDOI.R
+++ b/R/crossrefDOI.R
@@ -96,7 +96,7 @@ parseCoinsArticle <- function(text, ...) {
         out$doi <- if(grep("doi", text[want])) {
             doi <- sub("^rft_id=", "", URLdecode(text[want]))
             doi <- sub(re, "\\1", doi)
-            sub("http://dx.doi.org/", "", doi, fixed = TRUE)
+            sub("https?://(dx\\.)?doi.org/", "", doi)
         } else {
             NA
         }

--- a/R/orcidWorks.R
+++ b/R/orcidWorks.R
@@ -40,7 +40,7 @@
     idents <- lapply(idents, unlist)
     idents <- do.call(rbind.data.frame, idents)
     names(idents) <- c("Type", "Identifier")
-    idents$Identifier <- sub("http://dx.doi.org/", "", idents$Identifier)
+    idents$Identifier <- sub("https?://(dx\\.)?doi.org/", "", idents$Identifier)
     out <- list(orcid = orcid, identifiers = idents, works = works,
                 retrieved = tstamp)
     class(out) <- "orcidWorks"


### PR DESCRIPTION
Hello!

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Thus, differed beginnings of DOI-URLs are out there. This PR updates the reg-ex to catch them all.

Cheers :-)